### PR TITLE
Add devcontainer configuration and update Proxmox setup with helm dep…

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,10 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
+
+# Install age-keygen
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends age \
+    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+# Install yq
+RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq && \
+    chmod +x /usr/bin/yq

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,57 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "Ubuntu 24.04",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"build": {
+		"dockerfile": "Dockerfile",
+		"context": ".."
+	},
+	"runArgs": ["--network=host"],
+	"features": {
+	    "ghcr.io/fabianschurig/devcontainer-features/oh-my-posh:latest": {
+            "theme": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/refs/heads/main/themes/powerlevel10k_rainbow.omp.json"
+        },
+        "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
+            "minikube":  "none"
+        },
+        "ghcr.io/devcontainers/features/terraform:1": {},
+        "ghcr.io/devcontainers-extra/features/ansible:2": {},
+        "ghcr.io/hspaans/devcontainer-features/ansible-lint:1": {},
+        "ghcr.io/goldsam/dev-container-features/flux2:1": {},
+        "ghcr.io/devcontainers-extra/features/talosctl:1": {},
+        "ghcr.io/devcontainers-extra/features/sops:1": {}
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "",
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"terminal.integrated.defaultProfile.linux": "zsh",
+				"terminal.integrated.profiles.linux": {
+					"zsh": {
+						"path": "/usr/bin/zsh"
+					}
+				}
+			},
+			"extensions": [
+				"github.copilot",
+				"github.copilot-chat",
+				"wholroyd.jinja",
+				"eamodio.gitlens",
+				"github.vscode-github-actions"
+			]
+		}
+	},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+	"containerEnv": {
+	}
+}

--- a/proxmox/Makefile
+++ b/proxmox/Makefile
@@ -63,6 +63,12 @@ kubeconfig: ## Download kubeconfig
 nodes: ## Show kubernetes nodes
 	@kubectl get nodes -owide --sort-by '{.metadata.name}' --label-columns topology.kubernetes.io/region,topology.kubernetes.io/zone,node.kubernetes.io/instance-type
 
+helm-install-deps:
+	helm repo add cilium https://helm.cilium.io/
+	helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
+	helm plugin list | grep -q diff || helm plugin install https://github.com/databus23/helm-diff
+	helm plugin list | grep -q secrets || helm plugin install https://github.com/jkroepke/helm-secrets
+
 system:
 	helm --kubeconfig=kubeconfig upgrade -i --namespace=kube-system --version=1.16.4 -f deployments/cilium.yaml \
 		cilium cilium/cilium

--- a/proxmox/auth.tf
+++ b/proxmox/auth.tf
@@ -3,9 +3,9 @@ provider "proxmox" {
   endpoint = "https://${var.proxmox_host}:8006/"
   insecure = true
 
-  # api_token = data.sops_file.envs.data["PROXMOX_VE_API_TOKEN"]
-  username = "root@pam"
-  password = data.sops_file.envs.data["PROXMOX_VE_PASSWORD"]
+  api_token = data.sops_file.envs.data["PROXMOX_VE_API_TOKEN"]
+  # username = "root@pam"
+  # password = data.sops_file.envs.data["PROXMOX_VE_PASSWORD"]
 
   ssh {
     username = "root"

--- a/proxmox/init/auth.tf
+++ b/proxmox/init/auth.tf
@@ -3,6 +3,5 @@ provider "proxmox" {
   endpoint = "https://${var.proxmox_host}:8006/"
   insecure = true
 
-  username = var.proxmox_token_id
-  password = var.proxmox_token_secret
+  api_token = "${var.proxmox_token_id}=${var.proxmox_token_secret}"
 }

--- a/proxmox/instances-worker.tf
+++ b/proxmox/instances-worker.tf
@@ -62,7 +62,7 @@ resource "proxmox_virtual_environment_file" "worker_machineconfig" {
 
 resource "proxmox_virtual_environment_file" "worker_metadata" {
   for_each     = local.workers
-  node_name    = each.value.node_name
+  node_name    = each.value.zone
   content_type = "snippets"
   datastore_id = "local"
 
@@ -82,7 +82,7 @@ resource "proxmox_virtual_environment_file" "worker_metadata" {
 resource "proxmox_virtual_environment_vm" "worker" {
   for_each    = local.workers
   name        = each.value.name
-  node_name   = each.value.node_name
+  node_name   = each.value.zone
   vm_id       = each.value.id
   description = "Talos worker node"
 
@@ -202,7 +202,7 @@ resource "proxmox_virtual_environment_vm" "worker" {
 
 resource "proxmox_virtual_environment_firewall_options" "worker" {
   for_each  = lookup(var.security_groups, "worker", "") == "" ? {} : local.workers
-  node_name = each.value.node_name
+  node_name = each.value.zone
   vm_id     = each.value.id
   enabled   = true
 
@@ -221,7 +221,7 @@ resource "proxmox_virtual_environment_firewall_options" "worker" {
 
 resource "proxmox_virtual_environment_firewall_rules" "worker" {
   for_each  = lookup(var.security_groups, "worker", "") == "" ? {} : local.workers
-  node_name = each.value.node_name
+  node_name = each.value.zone
   vm_id     = each.value.id
 
   rule {

--- a/proxmox/variables.tf
+++ b/proxmox/variables.tf
@@ -26,7 +26,7 @@ variable "vpc_main_cidr" {
 variable "release" {
   type        = string
   description = "The version of the Talos image"
-  default     = "1.8.4"
+  default     = "1.9.5"
 }
 
 data "sops_file" "tfvars" {
@@ -86,7 +86,7 @@ variable "instances" {
   type        = map(any)
   default = {
     "all" = {
-      version = "v1.31.4"
+      version = "v1.32.3"
     },
     "hvm-1" = {
       enabled         = false,


### PR DESCRIPTION
…endencies

First of all: Thank you very much @sergelogvinov for your great work on creating the Terraform to setup Talos Kubernetes cluster on Proxmox.

I add the following changes:
- Devcontainer based on Ubuntu 24.04
- `helm-install-deps` step in the Makefile to install all missing dependencies and plugins
- Fix of the no longer existing `node_name` which is the `zone` in `proxmox/instances-worker.tf`
- Use of the latest Talos 1.9.5 at the time being and the kubelet v1.32.3
- Use the api_token instead of username and password (+ commands to generate the api token on proxmox host)

This should also fix https://github.com/sergelogvinov/terraform-talos/issues/8 as I add the steps to the `README.md` to create the `.env.yaml`. By using the devcontainer environment it should also be guaranteed to work since it is exactly the same environment with the same versions of the sops, yq, and other dependencies.

FYI:
I only needed your system ansible role + my own  `/etc/network/interfaces` config, no dnsmasq, no iptables.
I used a VXLAN1 on vmbr1 over vmbr0 because I only have one physical network adapter on my nodes. Seems to work fine.

